### PR TITLE
remove unused jar include, add installLocation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,6 +20,5 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:22.1.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.sigilance.CardEdit" >
+    package="com.sigilance.CardEdit"
+    android:installLocation="auto" >
     <uses-permission android:name="android.permission.NFC" />
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Just small additions...

I looked into "aapt dump badging app/build/outputs/apk/app-debug.apk" but didn't see anything special or problematic. Still I can't install cardedit from Google Play on my device. Google Play says that it's incompatible. My own compilation works.
I suspect you somehow misconfigured the allowed devices in Google Play.
